### PR TITLE
Truncate sensitive cookie information

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -162,8 +162,12 @@ class Request {
 
     const copyOfHeaders = _.clone(this.headers);
     const authInfo = copyOfHeaders.authorization;
+    const cookieInfo = copyOfHeaders.cookie;
     if (authInfo != null) {
       copyOfHeaders.authorization = `...${authInfo.slice(-4)}`;
+    }
+    if (cookieInfo != null) {
+      copyOfHeaders.cookie = `...${cookieInfo.slice(-4)}`;
     }
 
     return `Request: ${JSON.stringify({

--- a/lib/Response.js
+++ b/lib/Response.js
@@ -151,10 +151,13 @@ class Response {
 
     const copyOfHeaders = _.clone(this.headers);
     const authInfo = copyOfHeaders.authorization;
+    const cookieInfo = copyOfHeaders.cookie;
     if (authInfo != null) {
       copyOfHeaders.authorization = `...${authInfo.slice(-4)}`;
     }
-
+    if (cookieInfo != null) {
+      copyOfHeaders.cookie = `...${cookieInfo.slice(-4)}`;
+    }
     return `Response: ${JSON.stringify({
       statusCode : this.statusCode,
       headers    : this.headers,


### PR DESCRIPTION
  * Cookie information such as a sid should not show up
  * Similar to sensitive authorization headers