### PR TITLE
modified Response.toString() to hide sensitive fields

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -155,7 +155,7 @@ class Request {
 
   /**
    * Returns a string representation of the request
-   *
+   * @param {object?} opts - handler options object; optional
    * @returns {string} - representation of the request
    */
   toString(opts) {
@@ -163,7 +163,8 @@ class Request {
     opts = _.defaults(opts, { hideSensitive : true });
     const blankedOut = '**********';
 
-    let copyOfHeaders, copyOfBody;
+    let copyOfHeaders;
+    let copyOfBody;
     if (opts.hideSensitive && this.sensitive != null) {
 
       copyOfBody = _.clone(this.body);

--- a/lib/Response.js
+++ b/lib/Response.js
@@ -144,24 +144,45 @@ class Response {
 
   /**
    * Returns a string representation of the response
-   *
+   * @param {object?} opts - handler options object; optional
    * @returns {string} - representation of the response
    */
-  toString() {
+  toString(opts) {
+    opts = opts || {};
+    opts = _.defaults(opts, { hideSensitive : true });
+    const blankedOut = '**********';
 
-    const copyOfHeaders = _.clone(this.headers);
-    const authInfo = copyOfHeaders.authorization;
-    const cookieInfo = copyOfHeaders.cookie;
-    if (authInfo != null) {
-      copyOfHeaders.authorization = `...${authInfo.slice(-4)}`;
-    }
-    if (cookieInfo != null) {
-      copyOfHeaders.cookie = `...${cookieInfo.slice(-4)}`;
+    let copyOfHeaders;
+    let copyOfBody;
+    if (opts.hideSensitive && this.sensitive != null) {
+
+      if (this.sensitive.headers != null) {
+        copyOfHeaders = _.clone(this.headers);
+        _.forEach(this.sensitive.headers, (k) => {
+          if (copyOfHeaders[k] != null) {
+            copyOfHeaders[k] = blankedOut;
+          }
+        });
+      }
+
+      if (this.sensitive.body != null) {
+        try {
+          copyOfBody = JSON.parse(this.getBody());
+          _.forEach(this.sensitive.body, (k) => {
+            if (copyOfBody[k] != null) {
+              copyOfBody[k] = blankedOut;
+            }
+          });
+        }
+        catch (e) {
+          copyOfBody = this.getBody();
+        }
+      }
     }
     return `Response: ${JSON.stringify({
       statusCode : this.statusCode,
-      headers    : this.headers,
-      body       : this.getBody()
+      headers    : copyOfHeaders || this.headers,
+      body       : copyOfBody || this.getBody()
     }, null, 2)}`;
   }
 


### PR DESCRIPTION
Fixes #24 
* Allows Response objects to be scrubbed of sensitive info when `toString` is called on them
* If the attached Response body is not valid JSON, it won't attempt to scrub the response body
* If toString is provided with a `{ hideSensitive: false }` option, it won't attempt to scrub the response body