### PR TITLE
one more change to acomodate when the Response body is already an object

### DIFF
--- a/lib/Response.js
+++ b/lib/Response.js
@@ -168,14 +168,16 @@ class Response {
       if (this.sensitive.body != null) {
         try {
           copyOfBody = JSON.parse(this.getBody());
+        }
+        catch (e) {
+          copyOfBody = _.clone(this.getBody());
+        }
+        if (_.isObject(copyOfBody)) {
           _.forEach(this.sensitive.body, (k) => {
             if (copyOfBody[k] != null) {
               copyOfBody[k] = blankedOut;
             }
           });
-        }
-        catch (e) {
-          copyOfBody = this.getBody();
         }
       }
     }

--- a/test/Response.test.js
+++ b/test/Response.test.js
@@ -193,6 +193,20 @@ describe('Response', () => {
       expect(JSON.parse(response.getBody()).password).to.equal('1234'); // make sure it didn't modify
     });
 
+    it('should not print out sensitive info when the response._lastAssignedBody is already an object', () => {
+      response = new Response();
+      response.setHeader('authorization', 'abcdefghijklmnopqrstuvwxyz');
+      response.setBody({ 'user' : 'bob', 'password' : '1234' });
+      response.statusCode = 200;
+      response.sensitive = {
+        headers : ['authorization'],
+        body    : ['password']
+      };
+      expect(response.toString().replace(/\s+/g, '')).to.eql('Response:{"statusCode":200,"headers":{"authorization":"**********"},"body":{"user":"bob","password":"**********"}}');
+      expect(response.headers.authorization).to.equal('abcdefghijklmnopqrstuvwxyz'); // make sure it didn't modify
+      expect(response.getBody().password).to.equal('1234'); // make sure it didn't modify
+    });
+
     it('should include the entire string body when response._lastAssignedBody is not valid json', () => {
       response = new Response();
       response.setHeader('authorization', 'abcdefghijklmnopqrstuvwxyz');


### PR DESCRIPTION
* Apparently the response body _can_ be stored as an object in certain circumstances, so we must accommodate that case as well.
* bonus test

Sorry about missing this edge case. If it looks good, please get it merged in and cut _one more release_ please 🙏 
